### PR TITLE
Adopting the network service changes made in Core 3.0.0

### DIFF
--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
@@ -347,6 +347,7 @@ class MediaOfflineService implements MediaHitProcessor {
                                             currentReportingSession);
                                 } else {
                                     int respCode = connection.getResponseCode();
+                                    connection.close();
 
                                     Log.debug(
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
@@ -383,8 +384,6 @@ class MediaOfflineService implements MediaHitProcessor {
 
                                 isReportingSession = false;
                                 currentReportingSession = null;
-
-                                connection.close();
                             }
 
                             // Note :- If http request succeeds, we can try sending next available

--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
@@ -383,9 +383,7 @@ class MediaOfflineService implements MediaHitProcessor {
 
                                 isReportingSession = false;
                                 currentReportingSession = null;
-                            }
 
-                            if (connection != null) {
                                 connection.close();
                             }
 

--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
@@ -247,7 +247,7 @@ class MediaOfflineService implements MediaHitProcessor {
                 Log.trace(
                         MediaInternalConstants.EXTENSION_LOG_TAG,
                         LOG_TAG,
-                        "reportCompletedSessions - Exiting as we are currently sending session"
+                        "reportCompletedSessions - Exiting as we are currently sending session."
                                 + " report.");
                 return false;
             }
@@ -300,7 +300,7 @@ class MediaOfflineService implements MediaHitProcessor {
                         MediaInternalConstants.EXTENSION_LOG_TAG,
                         LOG_TAG,
                         "reportCompletedSessions - Could not generate url for reporting downloaded"
-                                + " content report for session %s",
+                                + " content report for session %s.",
                         sessionID);
                 return false;
             }

--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
@@ -247,7 +247,7 @@ class MediaOfflineService implements MediaHitProcessor {
                 Log.trace(
                         MediaInternalConstants.EXTENSION_LOG_TAG,
                         LOG_TAG,
-                        "ReportCompletedSessions - Exiting as we are currently sending session"
+                        "reportCompletedSessions - Exiting as we are currently sending session"
                                 + " report.");
                 return false;
             }
@@ -258,7 +258,7 @@ class MediaOfflineService implements MediaHitProcessor {
                 Log.trace(
                         MediaInternalConstants.EXTENSION_LOG_TAG,
                         LOG_TAG,
-                        "ReportCompletedSessions - Exiting as we have no pending sessions to"
+                        "reportCompletedSessions - Exiting as we have no pending sessions to"
                                 + " report.");
                 return false;
             }
@@ -268,10 +268,10 @@ class MediaOfflineService implements MediaHitProcessor {
                 return false;
             }
 
-            Log.trace(
+            Log.debug(
                     MediaInternalConstants.EXTENSION_LOG_TAG,
                     LOG_TAG,
-                    "ReportCompletedSessions - Reporting Session %s.",
+                    "reportCompletedSessions - Reporting Session %s.",
                     sessionID);
             List<MediaHit> hits = mediaDBService.getHits(sessionID);
 
@@ -282,7 +282,7 @@ class MediaOfflineService implements MediaHitProcessor {
                 Log.warning(
                         MediaInternalConstants.EXTENSION_LOG_TAG,
                         LOG_TAG,
-                        "ReportCompletedSessions - Could not generate downloaded content report"
+                        "reportCompletedSessions - Could not generate downloaded content report"
                                 + " from persisted hits for session %s. Clearing persisted pings.",
                         sessionID);
                 mediasessionIDManager.updateSessionState(
@@ -299,7 +299,7 @@ class MediaOfflineService implements MediaHitProcessor {
                 Log.warning(
                         MediaInternalConstants.EXTENSION_LOG_TAG,
                         LOG_TAG,
-                        "ReportCompletedSessions - Could not generate url for reporting downloaded"
+                        "reportCompletedSessions - Could not generate url for reporting downloaded"
                                 + " content report for session %s",
                         sessionID);
                 return false;
@@ -341,16 +341,17 @@ class MediaOfflineService implements MediaHitProcessor {
                                     Log.debug(
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
                                             LOG_TAG,
-                                            "ReportCompletedSessions - Failed to report session"
+                                            "reportCompletedSessions - Failed to report session %s"
                                                     + " because the connection is null (network is"
-                                                    + " offline)");
+                                                    + " offline).",
+                                            currentReportingSession);
                                 } else {
                                     int respCode = connection.getResponseCode();
 
-                                    Log.trace(
+                                    Log.debug(
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
                                             LOG_TAG,
-                                            "ReportCompletedSessions - Http request completed for"
+                                            "reportCompletedSessions - Http request completed for"
                                                     + " session %s with status code %s.",
                                             currentReportingSession,
                                             respCode);
@@ -373,7 +374,7 @@ class MediaOfflineService implements MediaHitProcessor {
                                         Log.trace(
                                                 MediaInternalConstants.EXTENSION_LOG_TAG,
                                                 LOG_TAG,
-                                                "ReportCompletedSessions - Clearing persisted"
+                                                "reportCompletedSessions - Clearing persisted"
                                                         + " pings for session %s.",
                                                 currentReportingSession);
                                         mediaDBService.deleteHits(currentReportingSession);

--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaOfflineService.java
@@ -341,8 +341,9 @@ class MediaOfflineService implements MediaHitProcessor {
                                     Log.debug(
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
                                             LOG_TAG,
-                                            "ReportCompletedSessions - Http request error,"
-                                                    + " connection was null");
+                                            "ReportCompletedSessions - Failed to report session"
+                                                    + " because the connection is null (network is"
+                                                    + " offline)");
                                 } else {
                                     int respCode = connection.getResponseCode();
 

--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaSession.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaSession.java
@@ -281,7 +281,8 @@ class MediaSession {
                                 boolean shouldRetry = false;
 
                                 if (deviceOffline) {
-                                    // `trySendHit` verifies network connectivity before sending a
+                                    // `MediaReportHelper.isReadyToSendHit` verifies network
+                                    // connectivity before sending a
                                     // hit. If the network goes
                                     // offline after verification but before sending the hit, retry
                                     // the attempt regardless

--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaSession.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaSession.java
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.media.internal;
 
+import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.services.HttpMethod;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.NetworkRequest;
@@ -23,7 +24,7 @@ class MediaSession {
     private static final int HTTP_TIMEOUT_SEC = 5;
     private static final int HTTP_OK = 200;
     private static final int HTTP_MULTIPLE_CHOICES = 300;
-    private static final int RETRY_COUNT = 2;
+    @VisibleForTesting static final int RETRY_COUNT = 2;
     private static final long MAX_ALLOWED_DURATION_BETWEEN_HITS_MS = 60000;
 
     private final Object mutex;
@@ -210,15 +211,16 @@ class MediaSession {
                         request,
                         connection -> {
                             String mcSessionId = null;
-
+                            boolean deviceOffline = false;
                             do {
                                 if (connection == null) {
                                     Log.debug(
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
                                             LOG_TAG,
-                                            "trySendHit - (%s) Http request error, connection was"
-                                                    + " null",
+                                            "trySendHit - Failed to send the (%s) hit because the"
+                                                    + " connection is null (network is offline)",
                                             hitEventType);
+                                    deviceOffline = true;
                                     break;
                                 }
 
@@ -278,9 +280,18 @@ class MediaSession {
                             synchronized (mutex) {
                                 boolean shouldRetry = false;
 
-                                if (hitIsSessionStart
+                                if (deviceOffline) {
+                                    // `trySendHit` verifies network connectivity before sending a
+                                    // hit. If the network goes
+                                    // offline after verification but before sending the hit, retry
+                                    // the attempt regardless
+                                    // of the hit type. `trySendHit` will automatically resume when
+                                    // the network connection is
+                                    // restored.
+                                    shouldRetry = true;
+                                } else if (hitIsSessionStart
                                         && mcSessionId != null
-                                        && mcSessionId.length() > 0) {
+                                        && !mcSessionId.isEmpty()) {
                                     sessionID = mcSessionId;
                                 } else if (hitIsSessionStart) {
                                     shouldRetry = sessionStartRetryCount < RETRY_COUNT;

--- a/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaSession.java
+++ b/code/media/src/main/java/com/adobe/marketing/mobile/media/internal/MediaSession.java
@@ -218,7 +218,7 @@ class MediaSession {
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
                                             LOG_TAG,
                                             "trySendHit - Failed to send the (%s) hit because the"
-                                                    + " connection is null (network is offline)",
+                                                    + " connection is null (network is offline).",
                                             hitEventType);
                                     deviceOffline = true;
                                     break;
@@ -230,7 +230,7 @@ class MediaSession {
                                     Log.debug(
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
                                             LOG_TAG,
-                                            "trySendHit - (%s) Http failed with response code %d ",
+                                            "trySendHit - (%s) Http failed with response code %d.",
                                             hitEventType,
                                             respCode);
                                     break;
@@ -244,11 +244,11 @@ class MediaSession {
                                         connection.getResponsePropertyValue("Location");
 
                                 if (sessionResponseFragment == null) {
-                                    Log.trace(
+                                    Log.debug(
                                             MediaInternalConstants.EXTENSION_LOG_TAG,
                                             LOG_TAG,
                                             "trySendHit - (%s) Media collection endpoint returned"
-                                                    + " null location header",
+                                                    + " null location header.",
                                             hitEventType);
                                     break;
                                 }
@@ -259,7 +259,7 @@ class MediaSession {
                                         MediaInternalConstants.EXTENSION_LOG_TAG,
                                         LOG_TAG,
                                         "trySendHit - (%s) Media collection endpoint created"
-                                                + " internal session : %s",
+                                                + " internal session : %s.",
                                         hitEventType,
                                         mcSessionId);
 
@@ -274,7 +274,7 @@ class MediaSession {
                             Log.debug(
                                     MediaInternalConstants.EXTENSION_LOG_TAG,
                                     LOG_TAG,
-                                    "trySendHit - (%s) Finished http connection",
+                                    "trySendHit - (%s) Finished http connection.",
                                     hitEventType);
 
                             synchronized (mutex) {
@@ -302,6 +302,13 @@ class MediaSession {
 
                                 if (!shouldRetry) {
                                     removeHit();
+                                } else {
+                                    Log.debug(
+                                            MediaInternalConstants.EXTENSION_LOG_TAG,
+                                            LOG_TAG,
+                                            "trySendHit - Will attempt to retry sending %s hit"
+                                                    + " later.",
+                                            hitEventType);
                                 }
                             }
                         });

--- a/code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaOfflineServiceTests.java
+++ b/code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaOfflineServiceTests.java
@@ -835,9 +835,20 @@ public class MediaOfflineServiceTests {
         jsonHits.add(mockData.sessionStartJsonWithState);
         jsonHits.add(mockData.completeJson);
 
-        expectNetworkDataAndRespond(jsonHits, -1);
+        // When network service returns null connection (network offline), session should not be
+        // dropped.
+        mockNetworkService.setResponse(null);
+
         assertTrue(offlineService.reportCompletedSessions());
+        assertTrue(didSendNetworkRequest());
         assertTrue(mediaDBService.sessionPresent(sessionId));
+
+        mockNetworkService.reset();
+        expectNetworkDataAndRespond(jsonHits, 201);
+
+        assertTrue(offlineService.reportCompletedSessions());
+        assertTrue(didSendNetworkRequest());
+        assertFalse(mediaDBService.sessionPresent(sessionId));
     }
 }
 

--- a/code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaSessionTests.java
+++ b/code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaSessionTests.java
@@ -535,7 +535,7 @@ public class MediaSessionTests {
         assertEquals(1, mediaSession.getQueueSize());
 
         // In case of network failure, sessionStart hits are retried 2 more times being dropped.
-        // When network service returns null connection (device offline), hits should should not be
+        // When network service returns null connection (device offline), hits should not be
         // dropped.
         for (int i = 0; i <= MediaSession.RETRY_COUNT + 1; ++i) {
             mockNetworkService.reset();
@@ -552,7 +552,7 @@ public class MediaSessionTests {
         assertEquals(0, mediaSession.getQueueSize());
 
         // In case of network failure, media hits other than session start are dropped.
-        // When network service returns null connection (device offline), the hit should should not
+        // When network service returns null connection (device offline), the hit should not
         // be dropped.
         mediaSession.queueHit(mockData.play);
 

--- a/code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaSessionTests.java
+++ b/code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaSessionTests.java
@@ -535,7 +535,7 @@ public class MediaSessionTests {
         assertEquals(1, mediaSession.getQueueSize());
 
         // In case of network failure, sessionStart hits are retried 2 more times being dropped.
-        // When network service returns null connection (device offline), hits should should not be
+        // When network service returns null connection (network offline), hits should should not be
         // dropped.
         for (int i = 0; i <= MediaSession.RETRY_COUNT + 1; ++i) {
             mockNetworkService.reset();
@@ -552,7 +552,7 @@ public class MediaSessionTests {
         assertEquals(0, mediaSession.getQueueSize());
 
         // In case of network failure, media hits other than session start are dropped.
-        // When network service returns null connection (device offline), the hit should should not
+        // When network service returns null connection (network offline), the hit should should not
         // be dropped.
         mediaSession.queueHit(mockData.play);
 


### PR DESCRIPTION
In Android Core 3.0.0, the network service returns a null connection when the device is offline. 

Media extension already handles cases where the device is offline. This PR addresses a corner case in `MediaSession` where the device could go offline after initiating the network connection. These changes ensure that data isn't lost and is retried when the device reconnects.